### PR TITLE
Schema dumper update

### DIFF
--- a/lib/postgis_adapter.rb
+++ b/lib/postgis_adapter.rb
@@ -19,7 +19,7 @@ include GeoRuby::SimpleFeatures
 include SpatialAdapter
 
 #tables to ignore in migration : relative to PostGIS management of geometric columns
-ActiveRecord::SchemaDumper.ignore_tables << "spatial_ref_sys" << "geometry_columns"
+ActiveRecord::SchemaDumper.ignore_tables.concat( %w(spatial_ref_sys geometry_columns geography_columns) )
 
 #add a method to_yaml to the Geometry class which will transform a geometry in a form suitable to be used in a YAML file (such as in a fixture)
 GeoRuby::SimpleFeatures::Geometry.class_eval do

--- a/postgis_adapter.gemspec
+++ b/postgis_adapter.gemspec
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
      "lib/postgis_adapter.rb",
      "lib/postgis_adapter/acts_as_geom.rb",
      "lib/postgis_adapter/common_spatial_adapter.rb",
-     "lib/postgis_functions.rb",
-     "lib/postgis_functions/bbox.rb",
-     "lib/postgis_functions/class.rb",
-     "lib/postgis_functions/common.rb",
+     "lib/postgis_adapter/functions.rb",
+     "lib/postgis_adapter/functions/bbox.rb",
+     "lib/postgis_adapter/functions/class.rb",
+     "lib/postgis_adapter/functions/common.rb",
      "postgis_adapter.gemspec",
      "rails/init.rb",
      "spec/db/models_postgis.rb",
@@ -37,11 +37,10 @@ Gem::Specification.new do |s|
      "spec/postgis_adapter/acts_as_geom_spec.rb",
      "spec/postgis_adapter/common_spatial_adapter_spec.rb",
      "spec/postgis_adapter_spec.rb",
-     "spec/postgis_functions/bbox_spec.rb",
-     "spec/postgis_functions/class_spec.rb",
-     "spec/postgis_functions/common_spec.rb",
-     "spec/postgis_functions_spec.rb",
-     "spec/spec.opts",
+     "spec/postgis_adapter/functions/bbox_spec.rb",
+     "spec/postgis_adapter/functions/class_spec.rb",
+     "spec/postgis_adapter/functions/common_spec.rb",
+     "spec/postgis_adapter/functions_spec.rb",
      "spec/spec_helper.rb"
   ]
   s.homepage = %q{http://github.com/nofxx/postgis_adapter}
@@ -55,12 +54,12 @@ Gem::Specification.new do |s|
      "spec/db/schema_postgis.rb",
      "spec/postgis_adapter/acts_as_geom_spec.rb",
      "spec/postgis_adapter/common_spatial_adapter_spec.rb",
-     "spec/postgis_functions_spec.rb",
+     "spec/postgis_adapter/functions_spec.rb",
      "spec/spec_helper.rb",
      "spec/postgis_adapter_spec.rb",
-     "spec/postgis_functions/class_spec.rb",
-     "spec/postgis_functions/common_spec.rb",
-     "spec/postgis_functions/bbox_spec.rb"
+     "spec/postgis_adapter/functions/class_spec.rb",
+     "spec/postgis_adapter/functions/common_spec.rb",
+     "spec/postgis_adapter/functions/bbox_spec.rb"
   ]
 
   if s.respond_to? :specification_version then

--- a/spec/postgis_adapter/acts_as_geom_spec.rb
+++ b/spec/postgis_adapter/acts_as_geom_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper.rb'
+require File.dirname(__FILE__) + '/../../spec_helper.rb'
 
 class DiffColumn < ActiveRecord::Base
   acts_as_geom :ponto => :point

--- a/spec/postgis_adapter/common_spatial_adapter_spec.rb
+++ b/spec/postgis_adapter/common_spatial_adapter_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper.rb'
+require File.dirname(__FILE__) + '/../../spec_helper.rb'
 
 describe "CommonSpatialAdapter" do
 

--- a/spec/postgis_adapter/functions/bbox_spec.rb
+++ b/spec/postgis_adapter/functions/bbox_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper.rb'
+require File.dirname(__FILE__) + '/../../../spec_helper.rb'
 
 describe "Point" do
 

--- a/spec/postgis_adapter/functions/class_spec.rb
+++ b/spec/postgis_adapter/functions/class_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper.rb'
+require File.dirname(__FILE__) + '/../../../spec_helper.rb'
 
 describe "ClassMethods" do
   before(:all) do

--- a/spec/postgis_adapter/functions/common_spec.rb
+++ b/spec/postgis_adapter/functions/common_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper.rb'
+require File.dirname(__FILE__) + '/../../../spec_helper.rb'
 
 describe "Common Functions" do
 

--- a/spec/postgis_adapter/functions_spec.rb
+++ b/spec/postgis_adapter/functions_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper.rb'
+require File.dirname(__FILE__) + '/../../spec_helper.rb'
 
 describe "PostgisFunctions" do
   before(:all) do

--- a/spec/postgis_adapter_spec.rb
+++ b/spec/postgis_adapter_spec.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-require File.dirname(__FILE__) + '/spec_helper.rb'
+require File.dirname(__FILE__) + '/../spec_helper.rb'
 
 describe "PostgisAdapter" do
 


### PR DESCRIPTION
Hi Marcos

I have updated the schema dumper to work with the most recent PostGIS release: 1.5.2. It was missing geography_columns in the list of tables to ignore in schema dumper. Also most specs were broken.

Shoaib
